### PR TITLE
Changes for 6.3.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
     <groupId>com.forgerock.elasticsearch</groupId>
     <artifactId>es-changes-feed-plugin</artifactId>
-    <version>6.2.2</version>
+    <version>6.3.0</version>
 
     <properties>
-        <elasticsearch.version>6.2.2</elasticsearch.version>
+        <elasticsearch.version>6.3.0</elasticsearch.version>
         <plugin.java.version>1.8</plugin.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,6 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/elasticsearch/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
         </dependencySet>
@@ -15,11 +14,9 @@
     <files>
         <file>
             <source>target/classes/plugin-descriptor.properties</source>
-            <outputDirectory>/elasticsearch/</outputDirectory>
         </file>
         <file>
             <source>src/main/resources/plugin-security.policy</source>
-            <outputDirectory>/elasticsearch/</outputDirectory>
         </file>
     </files>
 </assembly>

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -5,6 +5,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexingOperationListener;
@@ -93,7 +94,6 @@ public class WebSocketIndexListener implements IndexingOperationListener {
         if (!filter(change, sources)) {
             return;
         }
-
         String message;
         try {
             XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput());
@@ -105,11 +105,10 @@ public class WebSocketIndexListener implements IndexingOperationListener {
                     .field("_version", change.getVersion())
                     .field("_operation", change.getOperation().toString());
             if (change.getSource() != null) {
-                builder.rawField("_source", change.getSource(), XContentType.JSON);
+                builder.rawField("_source", change.getSource().streamInput(), XContentType.JSON);
             }
             builder.endObject();
-
-            message = builder.string();
+            message = Strings.toString(builder);
         } catch (IOException e) {
             log.error("Failed to write JSON", e);
             return;

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,6 @@
 name=es-changes-feed-plugin
 description=A plugin which allows a client to create a websocket connection to an elasticsearch node and receive a feed of changes from the database.
 version=${project.version}
-jvm=true
 classname=com.forgerock.elasticsearch.changes.ChangesFeedPlugin
 java.version=${plugin.java.version}
 elasticsearch.version=${elasticsearch.version}


### PR DESCRIPTION
I've made all the changes to get the WebSocketServer running with Elasticsearch 6.3.0. The issue that remains is the silent failing of the websocket `org.glassfish.tyrus.server.Server` whenever a client attempts a connection. I run `sudo lsof -i -P -n | grep LISTEN` and ensure the 9400 port is open, but as soon as I attempt a ws client connection, I receive a `Recv failure: Connection reset by peer` and after that the port is not longer listed when I run the `lsof` command.

While this PR does get the websocket server running on 6.3.0, I'm wondering if you have thoughts on the issue I've described here?