### PR TITLE
filter change feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Each of the above patterns is can be either:
 * `*` All indices, types or documents
 * `id[,id]*` List of specific indices, types or documents
 
+Only for index_pattern, prefixes are matched. e.g. my-index-* would match anything which starts with my-index-
+
 So for example:
 
 `*` will match everything. This is the default value
@@ -71,9 +73,24 @@ So for example:
 
 `gb,us/user,tweet/*` will match all documents of type user or tweet in the gb or us indices
 
+`my-index-*/*/*` would match anything in any index that starts with my-index-
+
+
+
 ### changes.disable
 Disable the plugin through config. Setting this to true will stop the websocket server 
 from starting up and will not intercept and change requests.
+
+### changes.field.includes
+To receive filtered fields when changes occur, useful in huge documents
+* `*` All fields
+* `id[,id]*` List of specific fields
+
+So for example:
+
+`*` will match everything. This is the default value
+
+`_source.transaction.duration.us` will filter the transaction.duration.us field
 
 ## Messages
 

--- a/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
@@ -31,16 +31,21 @@ public class ChangesFeedPlugin extends Plugin {
     private static final String SETTING_PORT = "changes.port";
     private static final String SETTING_LISTEN_SOURCE = "changes.listenSource";
     private static final String SETTING_DISABLE = "changes.disable";
+    private static final String SETTING_FILTER = "changes.filter";
+
 
     private final Logger log = Loggers.getLogger(ChangesFeedPlugin.class);
     private final Set<Source> sources;
     private final boolean enabled;
+    private final List<String> filter;
     private final static WebSocketRegister REGISTER = new WebSocketRegister();
 
     public ChangesFeedPlugin(Settings settings) {
         log.info("Starting Changes Plugin");
 
         enabled = !settings.getAsBoolean(SETTING_DISABLE, false);
+        
+        filter = settings.getAsList(SETTING_FILTER, Collections.singletonList("*"));
 
         if (enabled) {
             int port = settings.getAsInt(SETTING_PORT, 9400);
@@ -59,7 +64,7 @@ public class ChangesFeedPlugin extends Plugin {
     @Override
     public void onIndexModule(IndexModule indexModule) {
         if (enabled) {
-            indexModule.addIndexOperationListener(new WebSocketIndexListener(sources, REGISTER));
+            indexModule.addIndexOperationListener(new WebSocketIndexListener(sources, filter, REGISTER));
         }
         super.onIndexModule(indexModule);
     }
@@ -69,6 +74,7 @@ public class ChangesFeedPlugin extends Plugin {
         settings.add(Setting.simpleString(SETTING_PORT, Setting.Property.NodeScope));
         settings.add(Setting.simpleString(SETTING_LISTEN_SOURCE, Setting.Property.NodeScope));
         settings.add(Setting.simpleString(SETTING_DISABLE, Setting.Property.NodeScope));
+        settings.add(Setting.simpleString(SETTING_FILTER, Setting.Property.NodeScope));
         return settings;
     }
 

--- a/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
@@ -1,5 +1,11 @@
 package com.forgerock.elasticsearch.changes;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /*
     Copyright 2015 ForgeRock AS
 
@@ -22,9 +28,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.plugins.Plugin;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class ChangesFeedPlugin extends Plugin {
 

--- a/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/ChangesFeedPlugin.java
@@ -34,7 +34,7 @@ public class ChangesFeedPlugin extends Plugin {
     private static final String SETTING_PORT = "changes.port";
     private static final String SETTING_LISTEN_SOURCE = "changes.listenSource";
     private static final String SETTING_DISABLE = "changes.disable";
-    private static final String SETTING_FILTER = "changes.filter";
+    private static final String SETTING_FILTER = "changes.field.includes";
 
 
     private final Logger log = Loggers.getLogger(ChangesFeedPlugin.class);

--- a/src/main/java/com/forgerock/elasticsearch/changes/Source.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/Source.java
@@ -24,7 +24,6 @@ public class Source {
     private final Set<String> indices;
     private final Set<String> types;
     private final Set<String> ids;
-    private final Set<String> fields;
 
     public Source(String source) {
         String[] parts = source.split("/");
@@ -43,11 +42,6 @@ public class Source {
             ids = null;
         }
         
-        if (parts.length > 3) {
-            fields = parts[3].equals("*") ? null : new HashSet<>(Arrays.asList(parts[3].split(",")));
-        } else {
-        	fields = null;
-        }
     }
 
     public Set<String> getIds() {
@@ -60,10 +54,6 @@ public class Source {
 
     public Set<String> getTypes() {
         return types;
-    }
-    
-    public Set<String> getFileds() {
-        return fields;
     }
 
 }

--- a/src/main/java/com/forgerock/elasticsearch/changes/Source.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/Source.java
@@ -24,6 +24,7 @@ public class Source {
     private final Set<String> indices;
     private final Set<String> types;
     private final Set<String> ids;
+    private final Set<String> fields;
 
     public Source(String source) {
         String[] parts = source.split("/");
@@ -41,6 +42,12 @@ public class Source {
         } else {
             ids = null;
         }
+        
+        if (parts.length > 3) {
+            fields = parts[3].equals("*") ? null : new HashSet<>(Arrays.asList(parts[3].split(",")));
+        } else {
+        	fields = null;
+        }
     }
 
     public Set<String> getIds() {
@@ -53,6 +60,10 @@ public class Source {
 
     public Set<String> getTypes() {
         return types;
+    }
+    
+    public Set<String> getFileds() {
+        return fields;
     }
 
 }

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -73,14 +73,15 @@ public class WebSocketIndexListener implements IndexingOperationListener {
  
         	boolean result = false;        	
         	for (String s : source.getIndices() ) {	      		        		
-        		if (index.startsWith(s)) {
+        		if ( s != null && s.length() > 0 && s.endsWith("*") && index.startsWith(s.substring(0, s.length()-1))) {
                     result = true;
                     break;
         		}      		
         	}
         	
-        	if (result == false )
-            return false;			 	
+        	if (result == false ) {
+            return false;		
+        	}
         } 
 
         if (source.getTypes() != null && !source.getTypes().contains(type)) {

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -15,6 +15,7 @@ import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -26,10 +27,12 @@ public class WebSocketIndexListener implements IndexingOperationListener {
     private final Logger log = Loggers.getLogger(WebSocketIndexListener.class);
 
     private final Set<Source> sources;
+    private final List<String> filter;
     private final WebSocketRegister register;
 
-    WebSocketIndexListener(Set<Source> sources, WebSocketRegister register) {
+    WebSocketIndexListener(Set<Source> sources, List<String> filter, WebSocketRegister register) {
         this.sources = sources;
+        this.filter = filter;
         this.register = register;
     }
 
@@ -68,14 +71,15 @@ public class WebSocketIndexListener implements IndexingOperationListener {
     private static boolean filter(String index, String type, String id, Source source) {
     	
         if (source.getIndices() != null && !source.getIndices().contains(index) ) {
-        	boolean result = false;
-        	
+ 
+        	boolean result = false;        	
         	for (String s : source.getIndices() ) {	      		        		
         		if (index.startsWith(s)) {
                     result = true;
                     break;
         		}      		
         	}
+        	
         	if (result == false )
             return false;			 	
         } 
@@ -108,13 +112,8 @@ public class WebSocketIndexListener implements IndexingOperationListener {
         }
         String message;
         
-        Set<String> filters = new HashSet<>();
+        Set<String> filters = new HashSet<>(filter);
         
-        for (Source source : sources) {
-        	if (source.getFileds()!=null)
-        		filters.addAll(source.getFileds());
-        }
-           
         try {
             XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput(), filters);
             builder.startObject()

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -3,6 +3,7 @@ package com.forgerock.elasticsearch.changes;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.Strings;
@@ -95,8 +96,13 @@ public class WebSocketIndexListener implements IndexingOperationListener {
             return;
         }
         String message;
+        
+        Set<String> filters = Sets.newHashSet(
+                "_source.transaction.**",
+                "_source.timestamp.us");
+        
         try {
-            XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput());
+            XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput(), filters);
             builder.startObject()
                     .field("_index", change.getIndex())
                     .field("_type", change.getType())

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -65,9 +66,19 @@ public class WebSocketIndexListener implements IndexingOperationListener {
     }
 
     private static boolean filter(String index, String type, String id, Source source) {
-        if (source.getIndices() != null && !source.getIndices().contains(index)) {
-            return false;
-        }
+    	
+        if (source.getIndices() != null && !source.getIndices().contains(index) ) {
+        	boolean result = false;
+        	
+        	for (String s : source.getIndices() ) {	      		        		
+        		if (index.startsWith(s)) {
+                    result = true;
+                    break;
+        		}      		
+        	}
+        	if (result == false )
+            return false;			 	
+        } 
 
         if (source.getTypes() != null && !source.getTypes().contains(type)) {
             return false;
@@ -97,10 +108,13 @@ public class WebSocketIndexListener implements IndexingOperationListener {
         }
         String message;
         
-        Set<String> filters = Sets.newHashSet(
-                "_source.transaction.**",
-                "_source.timestamp.us");
-          
+        Set<String> filters = new HashSet<>();
+        
+        for (Source source : sources) {
+        	if (source.getFileds()!=null)
+        		filters.addAll(source.getFileds());
+        }
+           
         try {
             XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput(), filters);
             builder.startObject()

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -1,22 +1,21 @@
 package com.forgerock.elasticsearch.changes;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.joda.time.DateTime;
-
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Date: 04/05/2017

--- a/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
+++ b/src/main/java/com/forgerock/elasticsearch/changes/WebSocketIndexListener.java
@@ -100,7 +100,7 @@ public class WebSocketIndexListener implements IndexingOperationListener {
         Set<String> filters = Sets.newHashSet(
                 "_source.transaction.**",
                 "_source.timestamp.us");
-        
+          
         try {
             XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, new BytesStreamOutput(), filters);
             builder.startObject()


### PR DESCRIPTION
two functions 

* changes.filter :  `id[,id]* ` to receive filtered fileds when changes occur in documents (useful to save bandwidth) 
* changes.listenSource : `<index_pattern>` matches index prefix [ useful for daily  indices - eg. logstash-yyyy.mm.dd ]
